### PR TITLE
chore .ts .tsx使用eslint规则校验

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,22 @@
 {
-  "extends": "eslint-config-umi"
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "jsx": true,
+    "useJSXTextNode": true,
+    "ecmaVersion":  2018,
+    "sourceType":  "module"
+  },
+  "extends": [
+    "plugin:@typescript-eslint/recommended",
+    "prettier/@typescript-eslint",
+    "plugin:prettier/recommended",
+    "eslint-config-umi"
+  ],
+  "plugins": ["@typescript-eslint", "react-hooks", "react"],
+  "rules": {
+    "react/jsx-uses-vars": 1,
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,15 @@
     "tslint-react": "^3.6.0",
     "tslint-react-hooks": "^2.1.0",
     "typescript": "^3.1.3",
-    "umi-plugin-react": "^1.1.1"
+    "umi-plugin-react": "^1.1.1",
+    "eslint-config-prettier": "^4.2.0",
+    "eslint-plugin-prettier": "^3.1.0",
+    "eslint-plugin-react-hooks": "^1.6.0",
+    "prettier": "^1.17.0",
+    "@typescript-eslint/eslint-plugin": "^1.9.0",
+    "@typescript-eslint/parser": "^1.9.0",
+    "eslint-plugin-react": "^7.13.0"
+
   },
   "dependencies": {
     "antd": "^3.16.4",


### PR DESCRIPTION
在atom等没用自带lint插件的编辑器上使用 eslint代替tslint校验

p.s.  在linter-eslint 中增加.ts ,.tsx的校验支持, .ts,.tsx还是按照ts语法解析